### PR TITLE
Add support for multiple services keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ View API documentation at http://localhost:8080/swagger/index.html.
 | LOG_LEVEL | No | Logging level (default: info) |
 | OPAQUE_FAKE_RECORD | No | Use OPAQUE fake record to prevent client enumeration attacks |
 | VERIFY_FRONTEND_URL | No | Frontend URL to use in verification emails |
-| BRAVE_SERVICES_KEY | No | Services key to check against (via the `Brave-Key` header) for all requests |
+| BRAVE_SERVICES_KEY | No | Comma-separated list of services keys to check against (via the `Brave-Key` header) for all requests |
 | WEBHOOK_KEYS | No | A list of URLs and corresponding API keys for sending account event webhooks, delimited by a comma. Each entry should use the following format: `webhook url=webhook api key` |
 | DEV_ENDPOINTS_ENABLED | No | Enable the development-only endpoints |
 | ALLOWED_ORIGINS | No | List of allowed origins for CORS, separated by comma |

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -152,6 +152,27 @@ func (suite *MiddlewareTestSuite) TestServicesKeyMiddleware() {
 	req = httptest.NewRequest("GET", "/", nil)
 	resp = util.ExecuteTestRequest(req, mw(handler))
 	suite.Equal(http.StatusUnauthorized, resp.Code)
+
+	// Set multiple services keys
+	suite.T().Setenv("BRAVE_SERVICES_KEY", ",test-key1,,test-key2,test-key3,")
+	mw = middleware.ServicesKeyMiddleware(util.ProductionEnv)
+
+	// Test first valid key
+	req = httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("brave-key", "test-key1")
+	resp = util.ExecuteTestRequest(req, mw(handler))
+	suite.Equal(http.StatusOK, resp.Code)
+
+	// Test second valid key
+	req = httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("brave-key", "test-key2")
+	resp = util.ExecuteTestRequest(req, mw(handler))
+	suite.Equal(http.StatusOK, resp.Code)
+
+	// Test missing key
+	req = httptest.NewRequest("GET", "/", nil)
+	resp = util.ExecuteTestRequest(req, mw(handler))
+	suite.Equal(http.StatusUnauthorized, resp.Code)
 }
 
 func (suite *MiddlewareTestSuite) TestVerificationAuthMiddleware() {


### PR DESCRIPTION
This adds support for passing multiple services keys via the environment variable. We will need to configure both the current & new keys before closing #23.