### PR TITLE
Allow all services to use the verification intent

### DIFF
--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -162,9 +162,8 @@ func (vc *VerificationController) VerifyInit(w http.ResponseWriter, r *http.Requ
 			intentAllowed = false
 		}
 	case datastore.VerificationIntent:
-		if requestData.Service != util.EmailAliasesServiceName && requestData.Service != util.PremiumServiceName {
-			intentAllowed = false
-		}
+		// All services are allowed to verify email addresses
+		intentAllowed = true
 	case datastore.RegistrationIntent, datastore.SetPasswordIntent:
 		if !vc.passwordAuthEnabled || requestData.Service != util.AccountsServiceName {
 			intentAllowed = false

--- a/controllers/verification_test.go
+++ b/controllers/verification_test.go
@@ -201,11 +201,6 @@ func (suite *VerificationTestSuite) TestVerifyInitIntentNotAllowed() {
 			passwordAuthEnabled: true,
 		},
 		{
-			intent:              "verification",
-			service:             "accounts",
-			passwordAuthEnabled: true,
-		},
-		{
 			intent:              "registration",
 			service:             "premium",
 			passwordAuthEnabled: true,


### PR DESCRIPTION
All services should be able to use the email verification part of Accounts.