### PR TITLE
Password change enhancements

### DIFF
--- a/controllers/accounts.go
+++ b/controllers/accounts.go
@@ -213,12 +213,12 @@ func (ac *AccountsController) Router(verificationMiddleware func(http.Handler) h
 }
 
 func checkVerificationStatusAndIntent(w http.ResponseWriter, r *http.Request, verification *datastore.Verification) bool {
-	if verification.Intent == datastore.SetPasswordIntent && !verification.Verified {
+	if (verification.Intent == datastore.ResetPasswordIntent || verification.Intent == datastore.ChangePasswordIntent) && !verification.Verified {
 		util.RenderErrorResponse(w, r, http.StatusForbidden, util.ErrEmailNotVerified)
 		return false
 	}
 
-	if verification.Intent != datastore.RegistrationIntent && verification.Intent != datastore.SetPasswordIntent {
+	if verification.Intent != datastore.RegistrationIntent && verification.Intent != datastore.ResetPasswordIntent && verification.Intent != datastore.ChangePasswordIntent {
 		util.RenderErrorResponse(w, r, http.StatusForbidden, util.ErrIncorrectVerificationIntent)
 		return false
 	}
@@ -270,6 +270,7 @@ func (ac *AccountsController) SetupPasswordInit(w http.ResponseWriter, r *http.R
 			*requestData.NewAccountEmail,
 			datastore.RegistrationIntent,
 			util.AccountsServiceName,
+			nil,
 		)
 		if err != nil {
 			if errors.Is(err, util.ErrTooManyVerifications) ||

--- a/controllers/accounts_test.go
+++ b/controllers/accounts_test.go
@@ -228,7 +228,7 @@ func (suite *AccountsTestSuite) TestRegistration() {
 	req = util.CreateJSONTestRequest("/v2/accounts/password/finalize", controllers.RegistrationRecord{
 		SerializedRecord: &serializedRecord,
 		// This setting should be ignored
-		InvalidateSessions: false,
+		InvalidateSessions: true,
 	})
 	req.Header.Set("Authorization", "Bearer "+*parsedResp.VerificationToken)
 

--- a/controllers/accounts_test.go
+++ b/controllers/accounts_test.go
@@ -102,9 +102,9 @@ func (suite *AccountsTestSuite) createAuthSession() (string, *datastore.Account)
 	return token, account
 }
 
-func (suite *AccountsTestSuite) TestSetPassword() {
-	// Create verification with set_password intent
-	verification, err := suite.ds.CreateVerification("test@example.com", "accounts", "set_password")
+func (suite *AccountsTestSuite) TestResetPassword() {
+	// Create verification with reset_password intent
+	verification, err := suite.ds.CreateVerification("test@example.com", "accounts", "reset_password")
 	suite.Require().NoError(err)
 	_, err = suite.ds.UpdateAndGetVerificationStatus(verification.ID, verification.Code)
 	suite.Require().NoError(err)
@@ -128,7 +128,7 @@ func (suite *AccountsTestSuite) TestSetPassword() {
 	var parsedResp controllers.RegistrationResponse
 	util.DecodeJSONTestResponse(suite.T(), resp.Body, &parsedResp)
 	suite.NotNil(parsedResp.SerializedResponse)
-	suite.Nil(parsedResp.VerificationToken) // No verification token for set_password intent
+	suite.Nil(parsedResp.VerificationToken) // No verification token for reset_password intent
 	serializedRegistationResp, err := hex.DecodeString(*parsedResp.SerializedResponse)
 	suite.Require().NoError(err)
 	registrationResp, err := suite.opaqueClient.Deserialize.RegistrationResponse(serializedRegistationResp)
@@ -339,9 +339,9 @@ func (suite *AccountsTestSuite) TestSetPasswordBadIntents() {
 	}
 }
 
-func (suite *AccountsTestSuite) TestSetPasswordUnverifiedEmail() {
+func (suite *AccountsTestSuite) TestResetPasswordUnverifiedEmail() {
 	// Create unverified verification
-	verification, err := suite.ds.CreateVerification("test@example.com", "accounts", "set_password")
+	verification, err := suite.ds.CreateVerification("test@example.com", "accounts", "reset_password")
 	suite.Require().NoError(err)
 
 	// Get verification token

--- a/controllers/verification_test.go
+++ b/controllers/verification_test.go
@@ -491,6 +491,8 @@ func (suite *VerificationTestSuite) TestVerifyInitChangePasswordRequiresAuth() {
 	email := "test@example.com"
 	account, err := suite.ds.GetOrCreateAccount(email)
 	suite.Require().NoError(err)
+	err = suite.ds.UpdateAccountLastEmailVerifiedAt(account.ID)
+	suite.Require().NoError(err)
 
 	// Test change_password intent without auth - should fail with ErrIntentNotAllowed
 	body := controllers.VerifyInitRequest{

--- a/datastore/verifications.go
+++ b/datastore/verifications.go
@@ -31,10 +31,11 @@ type Verification struct {
 }
 
 const (
-	AuthTokenIntent    = "auth_token"
-	VerificationIntent = "verification"
-	RegistrationIntent = "registration"
-	SetPasswordIntent  = "set_password"
+	AuthTokenIntent      = "auth_token"
+	VerificationIntent   = "verification"
+	RegistrationIntent   = "registration"
+	ResetPasswordIntent  = "reset_password"
+	ChangePasswordIntent = "change_password"
 
 	codeLength              = 32
 	verifyWaitMaxDuration   = 20 * time.Second

--- a/main.go
+++ b/main.go
@@ -162,6 +162,8 @@ func main() {
 	authMiddleware := middleware.AuthMiddleware(jwtService, datastore, minSessionVersion, true, true)
 	// validateAuthMiddleware will ensure a valid session is present with any service name
 	validateAuthMiddleware := middleware.AuthMiddleware(jwtService, datastore, minSessionVersion, false, true)
+	// optionalAuthMiddleware will validate an optional auth token; the request will continue without an auth token
+	optionalAuthMiddleware := middleware.AuthMiddleware(jwtService, datastore, minSessionVersion, true, false)
 	// verificationMiddleware will ensure a valid verification token is present
 	verificationMiddleware := middleware.VerificationAuthMiddleware(jwtService, datastore, true)
 	// optionalVerificationMiddleware will validate an optional verification token; the request will continue without a verification token
@@ -192,7 +194,7 @@ func main() {
 		if passwordAuthEnabled {
 			r.With(servicesKeyMiddleware).Mount("/accounts", accountsController.Router(verificationMiddleware, optionalVerificationMiddleware, authMiddleware, accountDeletionEnabled))
 		}
-		r.Mount("/verify", verificationController.Router(verificationMiddleware, servicesKeyMiddleware, devEndpointsEnabled))
+		r.Mount("/verify", verificationController.Router(verificationMiddleware, servicesKeyMiddleware, optionalAuthMiddleware, devEndpointsEnabled))
 		r.With(servicesKeyMiddleware).Mount("/sessions", sessionsController.Router(authMiddleware))
 		r.With(servicesKeyMiddleware).Mount("/keys", userKeysController.Router(authMiddleware))
 	})

--- a/misc/test-client-rust/src/main.rs
+++ b/misc/test-client-rust/src/main.rs
@@ -65,7 +65,7 @@ struct CliArgs {
 
     /// Set password mode flag
     #[arg(short, long)]
-    set_password: bool,
+    reset_password: bool,
 
     /// Email auth flag
     #[arg(short = 'e', long)]
@@ -202,8 +202,8 @@ fn verify(args: &CliArgs) -> (String, Option<String>) {
                 "verification"
             } else if args.email_auth {
                 "auth_token"
-            } else if args.set_password {
-                "set_password"
+            } else if args.reset_password {
+                "reset_password"
             } else {
                 "registration"
             }
@@ -535,7 +535,7 @@ fn main() {
         display_account_details(&args, auth_token.unwrap_or_default().as_str());
     } else if args.login {
         login(args);
-    } else if args.register || args.set_password {
+    } else if args.register || args.reset_password {
         set_password(args);
     } else if args.enable_totp {
         enable_totp(&args);

--- a/services/ses.go
+++ b/services/ses.go
@@ -241,7 +241,7 @@ func (s *SESService) SendVerificationEmail(ctx context.Context, email string, ve
 	case datastore.RegistrationIntent:
 		subjectMessageID = "RegistrationEmailSubject"
 		instructionsMessageID = "RegistrationEmailInstructions"
-	case datastore.SetPasswordIntent:
+	case datastore.ResetPasswordIntent, datastore.ChangePasswordIntent:
 		subjectMessageID = "SetPasswordEmailSubject"
 		instructionsMessageID = "SetPasswordEmailInstructions"
 	}

--- a/services/twofa.go
+++ b/services/twofa.go
@@ -37,6 +37,8 @@ type TwoFAAuthRequest struct {
 	TOTPCode *string `json:"totpCode,omitempty" validate:"required_without=RecoveryKey,excluded_with=RecoveryKey"`
 	// Recovery key for 2FA bypass (optional if TOTP code is provided)
 	RecoveryKey *string `json:"recoveryKey,omitempty" validate:"required_without=TOTPCode,excluded_with=TOTPCode"`
+	// Whether to invalidate existing sessions (only applicable when changing password)
+	InvalidateSessions bool `json:"invalidateSessions"`
 }
 
 // TwoFAService provides methods for managing two-factor authentication

--- a/services/verification.go
+++ b/services/verification.go
@@ -54,7 +54,7 @@ func (vs *VerificationService) maybeCreateVerificationToken(verification *datast
 	return &token, nil
 }
 
-func (vs *VerificationService) InitializeVerification(ctx context.Context, email, intent, service string) (*datastore.Verification, *string, error) {
+func (vs *VerificationService) InitializeVerification(ctx context.Context, email, intent, service string, session *datastore.SessionWithAccountInfo) (*datastore.Verification, *string, error) {
 	// Validate intent
 	intentAllowed := true
 	switch intent {
@@ -65,8 +65,15 @@ func (vs *VerificationService) InitializeVerification(ctx context.Context, email
 	case datastore.VerificationIntent:
 		// All services are allowed to verify email addresses
 		intentAllowed = true
-	case datastore.RegistrationIntent, datastore.SetPasswordIntent:
+	case datastore.RegistrationIntent, datastore.ResetPasswordIntent:
 		if !vs.passwordAuthEnabled || service != util.AccountsServiceName {
+			intentAllowed = false
+		}
+	case datastore.ChangePasswordIntent:
+		if !vs.passwordAuthEnabled || service != util.AccountsServiceName {
+			intentAllowed = false
+		}
+		if session == nil || session.Email != util.CanonicalizeEmail(email) {
 			intentAllowed = false
 		}
 	default:
@@ -83,7 +90,7 @@ func (vs *VerificationService) InitializeVerification(ctx context.Context, email
 	}
 
 	// Validate account requirements
-	if intent == datastore.RegistrationIntent || intent == datastore.SetPasswordIntent {
+	if intent == datastore.RegistrationIntent || intent == datastore.ResetPasswordIntent || intent == datastore.ChangePasswordIntent {
 		accountExists, err := vs.datastore.AccountExists(email)
 		if err != nil {
 			return nil, nil, err
@@ -91,7 +98,7 @@ func (vs *VerificationService) InitializeVerification(ctx context.Context, email
 		if intent == datastore.RegistrationIntent && accountExists {
 			return nil, nil, util.ErrAccountExists
 		}
-		if intent == datastore.SetPasswordIntent && !accountExists {
+		if (intent == datastore.ResetPasswordIntent || intent == datastore.ChangePasswordIntent) && !accountExists {
 			return nil, nil, util.ErrAccountDoesNotExist
 		}
 	}

--- a/services/verification.go
+++ b/services/verification.go
@@ -73,6 +73,9 @@ func (vs *VerificationService) InitializeVerification(ctx context.Context, email
 		if !vs.passwordAuthEnabled || service != util.AccountsServiceName {
 			intentAllowed = false
 		}
+		// A valid auth session is required because we allow the user to choose whether
+		// they wish to invalidate all sessions. We do not want to present this option
+		// for any other intent (i.e. password resets, where session invalidation is mandatory to reduce attack risk).
 		if session == nil || session.Email != util.CanonicalizeEmail(email) {
 			intentAllowed = false
 		}


### PR DESCRIPTION
Resolves https://github.com/brave/accounts/issues/73

- Replaces `set_password` intent with `reset_password` and `change_password` intents
- The `change_password` intent allows for optional session invalidation; a valid auth token is required for initializing the email verification flow as a result