### PR TITLE
Use the packaged version of pg_cron that's in trixie

### DIFF
--- a/pg.Dockerfile
+++ b/pg.Dockerfile
@@ -1,6 +1,3 @@
 FROM public.ecr.aws/docker/library/postgres:17
 
-RUN apt update && apt install -y git make gcc postgresql-server-dev-17
-
-RUN git clone https://github.com/citusdata/pg_cron
-RUN cd pg_cron && make && make install
+RUN apt-get update && apt-get install -y postgresql-17-cron


### PR DESCRIPTION
No need to build from source: https://packages.debian.org/trixie/postgresql-17-cron