### PR TITLE
Upgrade to golang 1.25

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup golang
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
-        go-version: '1.24'
+        go-version: '1.25'
     - name: Generate swagger
       run: go install github.com/swaggo/swag/cmd/swag@latest && swag init
     - name: Install dependencies

--- a/.github/workflows/static-swagger.yml
+++ b/.github/workflows/static-swagger.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup golang
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Generate swagger
         run: go install github.com/swaggo/swag/cmd/swag@latest && swag init
         working-directory: ./accounts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/golang:1.24-trixie as builder
+FROM public.ecr.aws/docker/library/golang:1.25-trixie as builder
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
Do we need to upgrade `go.mod` too, or is this enough to get us to use the latest compiler?