### PR TITLE
Add email field to auth finalize responses

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -71,6 +71,8 @@ type LoginFinalizeResponse struct {
 	AuthToken *string `json:"authToken"`
 	// Indicates if 2FA verification is required before authentication is complete
 	RequiresTwoFA bool `json:"requiresTwoFA"`
+	// Email address associated with the account
+	Email string `json:"email"`
 }
 
 // @Description	Response containing validated token details
@@ -104,6 +106,8 @@ type LoginFinalize2FAResponse struct {
 	// Indicates to the client that 2FA was disabled as a result of using a recovery
 	// key (and should probably lead to the user being invited to re-enable 2FA)
 	TwoFADisabled bool `json:"twoFADisabled"`
+	// Email address associated with the account
+	Email string `json:"email"`
 }
 
 func (req *LoginInitRequest) ToOpaqueKE1(opaqueService *services.OpaqueService) (*opaqueMsg.KE1, error) {
@@ -409,6 +413,7 @@ func (ac *AuthController) LoginFinalize(w http.ResponseWriter, r *http.Request) 
 
 	response := LoginFinalizeResponse{
 		RequiresTwoFA: loginState.RequiresTwoFA,
+		Email:         loginState.Email,
 	}
 	if !loginState.RequiresTwoFA {
 		// Create a session and return an auth token
@@ -494,6 +499,7 @@ func (ac *AuthController) LoginFinalize2FA(w http.ResponseWriter, r *http.Reques
 	response := LoginFinalize2FAResponse{
 		AuthToken:     authToken,
 		TwoFADisabled: requestData.RecoveryKey != nil,
+		Email:         loginState.Email,
 	}
 
 	render.Status(r, http.StatusOK)

--- a/controllers/auth_test.go
+++ b/controllers/auth_test.go
@@ -246,6 +246,7 @@ func (suite *AuthTestSuite) TestAuthLogin() {
 	finalizeResp, _ := suite.performLoginSteps()
 	suite.NotEmpty(finalizeResp.AuthToken)
 	suite.False(finalizeResp.RequiresTwoFA)
+	suite.Equal(suite.account.Email, finalizeResp.Email)
 
 	req := httptest.NewRequest("GET", "/v2/auth/validate", nil)
 	req.Header.Add("Authorization", "Bearer "+*finalizeResp.AuthToken)
@@ -258,6 +259,7 @@ func (suite *AuthTestSuite) TestAuthLogout() {
 	finalizeResp, _ := suite.performLoginSteps()
 	suite.NotEmpty(finalizeResp.AuthToken)
 	suite.False(finalizeResp.RequiresTwoFA)
+	suite.Equal(suite.account.Email, finalizeResp.Email)
 
 	req := util.CreateJSONTestRequest("/v2/auth/logout", nil)
 	req.Header.Set("Authorization", "Bearer "+*finalizeResp.AuthToken)
@@ -538,6 +540,7 @@ func (suite *AuthTestSuite) TestAuth2FAWithTOTPCode() {
 	util.DecodeJSONTestResponse(suite.T(), resp.Body, &parsedTwoFAResp)
 	suite.NotEmpty(parsedTwoFAResp.AuthToken)
 	suite.False(parsedTwoFAResp.TwoFADisabled)
+	suite.Equal(suite.account.Email, parsedTwoFAResp.Email)
 
 	// Perform login steps again to get a new login state
 	finalizeResp, loginToken = suite.performLoginSteps()
@@ -616,6 +619,7 @@ func (suite *AuthTestSuite) TestAuth2FAWithRecoveryKey() {
 	util.DecodeJSONTestResponse(suite.T(), resp.Body, &parsedRecoveryResp)
 	suite.NotEmpty(parsedRecoveryResp.AuthToken)
 	suite.True(parsedRecoveryResp.TwoFADisabled)
+	suite.Equal(suite.account.Email, parsedRecoveryResp.Email)
 
 	// Verify the auth token works
 	validateReq := httptest.NewRequest("GET", "/v2/auth/validate", nil)
@@ -632,6 +636,7 @@ func (suite *AuthTestSuite) TestAuth2FAWithRecoveryKey() {
 	finalizeResp, _ = suite.performLoginSteps()
 	suite.False(finalizeResp.RequiresTwoFA)
 	suite.NotNil(finalizeResp.AuthToken)
+	suite.Equal(suite.account.Email, finalizeResp.Email)
 
 	validateReq = httptest.NewRequest("GET", "/v2/auth/validate", nil)
 	validateReq.Header.Add("Authorization", "Bearer "+*finalizeResp.AuthToken)


### PR DESCRIPTION
Adding this field so that the client doesn't have to use the validate endpoint to retrieve the email, shortly after logging in.