### PR TITLE
Switch from SES Client.SendEmail() to Client.SendRawEmail()

### DIFF
--- a/services/ses.go
+++ b/services/ses.go
@@ -3,10 +3,14 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	_ "embed"
 	"errors"
 	"fmt"
 	htmlTemplate "html/template"
+	"io"
+	"mime"
+	"mime/quotedprintable"
 	"os"
 	"strconv"
 	textTemplate "text/template"
@@ -173,7 +177,58 @@ func NewSESService(i18nBundle *i18n.Bundle, env string) (*SESService, error) {
 	}, nil
 }
 
-func (s *SESService) sendEmail(ctx context.Context, email string, subject string, contents interface{}, htmlTemplate *htmlTemplate.Template, textTemplate *textTemplate.Template) error {
+func quotePrint(w io.Writer, content string) error {
+	qpw := quotedprintable.NewWriter(w)
+	if _, err := qpw.Write([]byte(content)); err != nil {
+		return err
+	}
+	return qpw.Close()
+}
+
+func buildRawEmail(to, subject, textContent, htmlContent string, extraHeaders map[string]string) ([]byte, error) {
+	boundaryBytes := make([]byte, 12)
+	if _, err := io.ReadFull(rand.Reader, boundaryBytes); err != nil {
+		return nil, fmt.Errorf("failed to generate boundary: %w", err)
+	}
+	boundary := fmt.Sprintf("----=_Part_%X", boundaryBytes)
+
+	var buf bytes.Buffer
+
+	// Headers
+	buf.WriteString("To: " + to + "\r\n")
+	buf.WriteString("Subject: " + mime.QEncoding.Encode("UTF-8", subject) + "\r\n")
+	buf.WriteString("MIME-Version: 1.0\r\n")
+	buf.WriteString("Content-Type: multipart/alternative; boundary=\"" + boundary + "\"\r\n")
+	for k, v := range extraHeaders {
+		buf.WriteString(k + ": " + mime.QEncoding.Encode("UTF-8", v) + "\r\n")
+	}
+	buf.WriteString("\r\n")
+
+	// text/plaintext body
+	buf.WriteString("--" + boundary + "\r\n")
+	buf.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
+	buf.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
+	buf.WriteString("\r\n")
+	if err := quotePrint(&buf, textContent); err != nil {
+		return nil, fmt.Errorf("failed to encode text content: %w", err)
+	}
+	buf.WriteString("\r\n")
+
+	// text/html body
+	buf.WriteString("--" + boundary + "\r\n")
+	buf.WriteString("Content-Type: text/html; charset=UTF-8\r\n")
+	buf.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
+	buf.WriteString("\r\n")
+	if err := quotePrint(&buf, htmlContent); err != nil {
+		return nil, fmt.Errorf("failed to encode HTML content: %w", err)
+	}
+	buf.WriteString("\r\n")
+
+	buf.WriteString("--" + boundary + "--\r\n")
+	return buf.Bytes(), nil
+}
+
+func (s *SESService) sendEmail(ctx context.Context, email string, subject string, contents interface{}, htmlTemplate *htmlTemplate.Template, textTemplate *textTemplate.Template, headers map[string]string) error {
 	var htmlContent, textContent bytes.Buffer
 	if err := htmlTemplate.Execute(&htmlContent, contents); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
@@ -181,25 +236,17 @@ func (s *SESService) sendEmail(ctx context.Context, email string, subject string
 	if err := textTemplate.Execute(&textContent, contents); err != nil {
 		return fmt.Errorf("failed to execute template: %w", err)
 	}
-	htmlContentString := htmlContent.String()
-	textContentString := textContent.String()
 
-	input := &ses.SendEmailInput{
-		Destination: &types.Destination{
-			ToAddresses: []string{util.CanonicalizeEmail(email)},
-		},
-		Message: &types.Message{
-			Body: &types.Body{
-				Html: &types.Content{
-					Data: &htmlContentString,
-				},
-				Text: &types.Content{
-					Data: &textContentString,
-				},
-			},
-			Subject: &types.Content{
-				Data: &subject,
-			},
+	toEmail := util.CanonicalizeEmail(email)
+	rawMessage, err := buildRawEmail(toEmail, subject, textContent.String(), htmlContent.String(), headers)
+	if err != nil {
+		return fmt.Errorf("failed to build raw email: %w", err)
+	}
+
+	input := &ses.SendRawEmailInput{
+		Destinations: []string{toEmail},
+		RawMessage: &types.RawMessage{
+			Data: rawMessage,
 		},
 		Source: &s.fromAddress,
 	}
@@ -208,7 +255,7 @@ func (s *SESService) sendEmail(ctx context.Context, email string, subject string
 		input.ConfigurationSetName = &s.configSet
 	}
 
-	_, err := s.client.SendEmail(ctx, input)
+	_, err = s.client.SendRawEmail(ctx, input)
 	if err != nil {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) {
@@ -257,7 +304,7 @@ func (s *SESService) SendVerificationEmail(ctx context.Context, email string, ve
 		ExpiryDisclaimer:   localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "VerifyEmailExpiryDisclaimer"}),
 	}
 
-	if err := s.sendEmail(ctx, email, data.Subject, &data, s.verifyHTMLTemplate, s.verifyTextTemplate); err != nil {
+	if err := s.sendEmail(ctx, email, data.Subject, &data, s.verifyHTMLTemplate, s.verifyTextTemplate, nil); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
 
@@ -274,7 +321,7 @@ func (s *SESService) SendSimilarEmailAlert(ctx context.Context, email string, lo
 		Message:     localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "SimilarEmailLoginMessage", TemplateData: map[string]string{"Email": email}}),
 	}
 
-	if err := s.sendEmail(ctx, email, data.Subject, &data, s.generalHTMLTemplate, s.generalTextTemplate); err != nil {
+	if err := s.sendEmail(ctx, email, data.Subject, &data, s.generalHTMLTemplate, s.generalTextTemplate, nil); err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
 
@@ -289,7 +336,7 @@ func (s *SESService) SendPasswordChangeNotification(ctx context.Context, email s
 		Message:     localizer.MustLocalize(&i18n.LocalizeConfig{MessageID: "PasswordChangeNotificationMessage"}),
 	}
 
-	if err := s.sendEmail(ctx, email, data.Subject, &data, s.generalHTMLTemplate, s.generalTextTemplate); err != nil {
+	if err := s.sendEmail(ctx, email, data.Subject, &data, s.generalHTMLTemplate, s.generalTextTemplate, nil); err != nil {
 		return fmt.Errorf("failed to send password change notification email: %w", err)
 	}
 

--- a/services/ses_test.go
+++ b/services/ses_test.go
@@ -1,0 +1,162 @@
+package services
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingWriter struct{}
+
+func (f failingWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestBuildRawEmail(t *testing.T) {
+	to := "user@example.com"
+	subject := "Test Subject"
+	textContent := "Hello, this is plain text."
+	htmlContent := "<html><body>Hello, this is HTML.</body></html>"
+
+	t.Run("builds valid email structure", func(t *testing.T) {
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, nil)
+		require.NoError(t, err)
+		email := string(raw)
+
+		// Check headers in correct order
+		toIdx := strings.Index(email, "To: ")
+		subjectIdx := strings.Index(email, "Subject: ")
+		mimeIdx := strings.Index(email, "MIME-Version: ")
+		contentTypeIdx := strings.Index(email, "Content-Type: multipart/alternative")
+
+		assert.True(t, toIdx < subjectIdx, "To should come before Subject")
+		assert.True(t, subjectIdx < mimeIdx, "Subject should come before MIME-Version")
+		assert.True(t, mimeIdx < contentTypeIdx, "MIME-Version should come before Content-Type")
+	})
+
+	t.Run("includes correct header values", func(t *testing.T) {
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, nil)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "To: user@example.com\r\n")
+		assert.Contains(t, email, "Subject: Test Subject\r\n")
+		assert.Contains(t, email, "MIME-Version: 1.0\r\n")
+		assert.NotContains(t, email, "From:")
+	})
+
+	t.Run("includes both text and HTML parts", func(t *testing.T) {
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, nil)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "Content-Type: text/plain; charset=UTF-8")
+		assert.Contains(t, email, "Content-Type: text/html; charset=UTF-8")
+		assert.Contains(t, email, textContent)
+		assert.Contains(t, email, htmlContent)
+	})
+
+	t.Run("includes custom headers", func(t *testing.T) {
+		headers := map[string]string{
+			"Custom-Header": "custom-value",
+			"X-Another":     "another-value",
+		}
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, headers)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "Custom-Header: custom-value\r\n")
+		assert.Contains(t, email, "X-Another: another-value\r\n")
+	})
+
+	t.Run("Q-encodes non-ASCII custom header values", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Mas": "noël",
+		}
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, headers)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "X-Mas: =?UTF-8?q?")
+		assert.NotContains(t, email, "X-Mas: noël")
+	})
+
+	t.Run("does not Q-encode ASCII-only custom header values", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Custom": "plain-ascii-value",
+		}
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, headers)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "X-Custom: plain-ascii-value\r\n")
+	})
+
+	t.Run("Q-encodes non-ASCII subject", func(t *testing.T) {
+		nonAsciiSubject := "Vérifiez votre adresse de courriel"
+		raw, err := buildRawEmail(to, nonAsciiSubject, textContent, htmlContent, nil)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "=?UTF-8?q?") // stdlib uses lowercase q
+		assert.NotContains(t, email, "Subject: Vérifiez")
+	})
+
+	t.Run("does not Q-encode ASCII-only subject", func(t *testing.T) {
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, nil)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "Subject: Test Subject\r\n")
+		assert.NotContains(t, email, "=?UTF-8?q?")
+	})
+
+	t.Run("boundary format matches expected pattern", func(t *testing.T) {
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, nil)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.Contains(t, email, "boundary=\"----=_Part_")
+	})
+
+	t.Run("email ends with closing boundary", func(t *testing.T) {
+		raw, err := buildRawEmail(to, subject, textContent, htmlContent, nil)
+		require.NoError(t, err)
+		email := string(raw)
+
+		assert.True(t, strings.HasSuffix(email, "--\r\n"))
+	})
+}
+
+func TestQuotePrint(t *testing.T) {
+	t.Run("writes ASCII content", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := quotePrint(&buf, "Hello, World!")
+		require.NoError(t, err)
+		assert.Equal(t, "Hello, World!", buf.String())
+	})
+
+	t.Run("encodes non-ASCII characters", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := quotePrint(&buf, "François")
+		require.NoError(t, err)
+		assert.Equal(t, "Fran=C3=A7ois", buf.String())
+	})
+
+	t.Run("handles empty content", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := quotePrint(&buf, "")
+		require.NoError(t, err)
+		assert.Equal(t, "", buf.String())
+	})
+
+	t.Run("returns error on write failure", func(t *testing.T) {
+		err := quotePrint(failingWriter{}, "test")
+		require.Error(t, err)
+		assert.Equal(t, "write failed", err.Error())
+	})
+}

--- a/templates/email_viewer.tmpl
+++ b/templates/email_viewer.tmpl
@@ -31,24 +31,106 @@
   <script>
     const messages = {{.Messages}};
     const messagesContainer = document.getElementById('messages');
+
+    function decodeQuotedPrintable(str) {
+      // Quoted-printable uses =XX for hex bytes, similar to percent-encoding's %XX.
+      // We escape literal % chars, convert =XX to %XX, then let decodeURIComponent handle UTF-8 decoding.
+      return decodeURIComponent(str.replace(/=\r?\n/g, '').replace(/%/g, '%25').replace(/=([0-9A-Fa-f]{2})/g, '%$1'));
+    }
+
+    function parseRawEmail(rawData) {
+      const result = { to: '', subject: '', textPart: '', htmlPart: '' };
+
+      // Split headers from body at first blank line
+      const headerEndIdx = rawData.search(/\r?\n\r?\n/);
+      if (headerEndIdx === -1) return result;
+
+      const headerSection = rawData.substring(0, headerEndIdx);
+      const bodySection = rawData.substring(headerEndIdx).replace(/^\r?\n\r?\n/, '');
+
+      // Parse headers (handle folded headers)
+      const headerLines = headerSection.replace(/\r?\n[ \t]+/g, ' ').split(/\r?\n/);
+      const headers = {};
+      for (const line of headerLines) {
+        const colonIdx = line.indexOf(':');
+        if (colonIdx > 0) {
+          const key = line.substring(0, colonIdx).toLowerCase();
+          headers[key] = line.substring(colonIdx + 1).trim();
+        }
+      }
+
+      result.to = headers['to'] || '';
+      result.subject = headers['subject'] || '';
+      // Decode MIME encoded subject
+      if (result.subject.includes('=?')) {
+        result.subject = result.subject.replace(/=\?UTF-8\?Q\?(.*?)\?=/gi, (_, encoded) => decodeQuotedPrintable(encoded.replace(/_/g, ' ')));
+      }
+
+      // Find boundary
+      const contentType = headers['content-type'] || '';
+      const boundaryMatch = contentType.match(/boundary="([^"]+)"/);
+      if (!boundaryMatch) return result;
+      const boundary = boundaryMatch[1];
+
+      // Split into MIME parts
+      const parts = bodySection.split('--' + boundary);
+
+      for (const part of parts) {
+        const trimmed = part.trim();
+        if (trimmed === '' || trimmed === '--') continue;
+
+        // Split part headers from part body
+        const partHeaderEnd = part.search(/\r?\n\r?\n/);
+        if (partHeaderEnd === -1) continue;
+
+        const partHeaderSection = part.substring(0, partHeaderEnd);
+        const partBody = part.substring(partHeaderEnd).replace(/^\r?\n\r?\n/, '');
+
+        // Parse part headers
+        const partHeaderLines = partHeaderSection.replace(/\r?\n[ \t]+/g, ' ').split(/\r?\n/);
+        const partHeaders = {};
+        for (const line of partHeaderLines) {
+          const colonIdx = line.indexOf(':');
+          if (colonIdx > 0) {
+            const key = line.substring(0, colonIdx).toLowerCase();
+            partHeaders[key] = line.substring(colonIdx + 1).trim();
+          }
+        }
+
+        const partContentType = partHeaders['content-type'] || '';
+        const isQuotedPrintable = (partHeaders['content-transfer-encoding'] || '').toLowerCase().includes('quoted-printable');
+        const decoded = isQuotedPrintable ? decodeQuotedPrintable(partBody) : partBody;
+
+        if (partContentType.includes('text/html')) {
+          result.htmlPart = decoded;
+        } else if (partContentType.includes('text/plain')) {
+          result.textPart = decoded;
+        }
+      }
+
+      return result;
+    }
+
     messages.forEach(message => {
       const messageDiv = document.createElement('div');
       messageDiv.className = 'message';
 
+      const parsed = parseRawEmail(message.RawData);
+
       const info = document.createElement('p');
-      info.textContent = `Timestamp: ${message.Timestamp}, To: ${message.Destination.ToAddresses.join(', ')}, Subject: ${message.Subject}`;
+      info.textContent = `Timestamp: ${message.Timestamp}, To: ${parsed.to}, Subject: ${parsed.subject}`;
       messageDiv.appendChild(info);
 
-      if (message.Body.html_part) {
+      if (parsed.htmlPart) {
         const iframe = document.createElement('iframe');
-        iframe.srcdoc = message.Body.html_part;
+        iframe.srcdoc = parsed.htmlPart;
         messageDiv.appendChild(iframe);
       }
 
-      if (message.Body.text_part) {
+      if (parsed.textPart) {
         const textContent = document.createElement('div');
         textContent.className = 'text-content';
-        textContent.textContent = message.Body.text_part;
+        textContent.textContent = parsed.textPart;
         messageDiv.appendChild(textContent);
       }
 


### PR DESCRIPTION
This allows us to add custom email headers, needed for #6, #86, and #114 .