### PR TITLE
Handle SES sending failures due to email address format

### DIFF
--- a/controllers/accounts.go
+++ b/controllers/accounts.go
@@ -465,6 +465,10 @@ func (ac *AccountsController) SetupPasswordFinalize(w http.ResponseWriter, r *ht
 	// Send verification email if this is a registration intent
 	if verification.Intent == datastore.RegistrationIntent {
 		if err := ac.verificationService.SendVerificationEmail(r.Context(), verification, locale); err != nil {
+			if errors.Is(err, util.ErrFailedToSendEmailInvalidFormat) {
+				util.RenderErrorResponse(w, r, http.StatusBadRequest, err)
+				return
+			}
 			util.RenderErrorResponse(w, r, http.StatusInternalServerError, err)
 			return
 		}


### PR DESCRIPTION
This is the same fix as in commit 25a0ef9c39aa82e0383a7ceaa754439d8a4bf6a4 but for a different caller.

Fixes #163