### PR TITLE
Limit email addresses to 254 characters

### DIFF
--- a/controllers/accounts.go
+++ b/controllers/accounts.go
@@ -47,7 +47,7 @@ type RegistrationRequest struct {
 	// Whether to serialize the response into binary/hex
 	SerializeResponse bool `json:"serializeResponse"`
 	// Email for new account creation (required if no verification token)
-	NewAccountEmail *string `json:"newAccountEmail" validate:"omitempty,email"`
+	NewAccountEmail *string `json:"newAccountEmail" validate:"omitempty,email,max=254"`
 	// Name of service that initiated the registration flow
 	InitiatingServiceName string `json:"initiatingServiceName" validate:"required,oneof=accounts email-aliases premium"`
 }

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -28,7 +28,7 @@ type AuthController struct {
 // @Description Request for account login
 type LoginInitRequest struct {
 	// Email address of the account
-	Email string `json:"email" validate:"required,email,ascii" example:"test@example.com"`
+	Email string `json:"email" validate:"required,email,ascii,max=254" example:"test@example.com"`
 	// Blinded message component of KE1
 	BlindedMessage *string `json:"blindedMessage" validate:"required_without=SerializedKE1"`
 	// Client ephemeral public key of KE1

--- a/controllers/server_keys.go
+++ b/controllers/server_keys.go
@@ -58,7 +58,7 @@ type TOTPGenerateRequest struct {
 	// AccountID is the UUID of the account for which to generate/delete a TOTP key
 	AccountID uuid.UUID `json:"accountId" validate:"required"`
 	// Email is the email address for the account (used for TOTP generation)
-	Email string `json:"email" validate:"required,email"`
+	Email string `json:"email" validate:"required,email,max=254"`
 }
 
 // TOTPGenerateResponse represents the response body containing the generated TOTP key

--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -32,7 +32,7 @@ type VerificationController struct {
 // @Description	Request to initialize email verification
 type VerifyInitRequest struct {
 	// Email address to verify
-	Email string `json:"email" validate:"required,email,ascii" example:"test@example.com"`
+	Email string `json:"email" validate:"required,email,ascii,max=254" example:"test@example.com"`
 	// Purpose of verification (e.g., get auth token, simple verification)
 	Intent string `json:"intent" validate:"required,oneof=auth_token verification reset_password change_password" example:"reset_password"`
 	// Service requesting the verification


### PR DESCRIPTION
https://www.rfc-editor.org/errata/eid1690

We have the same limit on the browser side.