### PR TITLE
Change verification code generation to be pattern-based

### DIFF
--- a/datastore/verifications.go
+++ b/datastore/verifications.go
@@ -2,9 +2,9 @@ package datastore
 
 import (
 	"crypto/rand"
-	"encoding/base32"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/brave/accounts/util"
@@ -45,7 +45,6 @@ const (
 	ResetPasswordIntent  = "reset_password"
 	ChangePasswordIntent = "change_password"
 
-	codeLength              = 6
 	VerificationExpiration  = 15 * time.Minute
 	maxPendingVerifications = 3
 	maxDailyVerifications   = 10
@@ -59,17 +58,40 @@ func (d *Datastore) validVerificationModel(v *Verification) *gorm.DB {
 	return d.DB.Model(v).Where("is_invalidated = false")
 }
 
-func generateVerificationCode() (string, error) {
-	b := make([]byte, codeLength)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("failed to generate random code: %w", err)
+const (
+	codeAlphabetFull  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234679" // 32 chars
+	codeAlphabetDigit = "234679"                           // 6 chars
+	codePattern       = "FFDFFD"                           // F = Full, D = Digit
+)
+
+func generateVerificationCode(pattern string) (string, error) {
+	if len(pattern) == 0 {
+		return "", fmt.Errorf("code pattern must not be empty")
 	}
-	return base32.StdEncoding.EncodeToString(b)[:codeLength], nil
+	out := make([]byte, len(pattern))
+	for i, char := range pattern {
+		var alphabet string
+		switch char {
+		case 'F':
+			alphabet = codeAlphabetFull
+		case 'D':
+			alphabet = codeAlphabetDigit
+		default:
+			return "", fmt.Errorf("invalid code pattern char %q", char)
+		}
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
+		if err != nil {
+			return "", fmt.Errorf("failed to generate random code: %w", err)
+		}
+		// Map random number to char in alphabet for the current position
+		out[i] = alphabet[idx.Int64()]
+	}
+	return string(out), nil
 }
 
 // CreateVerification creates a new verification record
 func (d *Datastore) CreateVerification(email string, service string, intent string) (*Verification, error) {
-	code, err := generateVerificationCode()
+	code, err := generateVerificationCode(codePattern)
 	if err != nil {
 		return nil, err
 	}

--- a/datastore/verifications_test.go
+++ b/datastore/verifications_test.go
@@ -1,0 +1,73 @@
+package datastore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type VerificationsTestSuite struct {
+	suite.Suite
+}
+
+func (suite *VerificationsTestSuite) TestGenerateVerificationCode() {
+	cases := []string{
+		"F",                // length 1, F branch
+		"D",                // length 1, D branch
+		"FFDFFD",           // length 6, both branches (production pattern)
+		"FFFFFFFFFFFFFFFF", // length 16
+	}
+
+	const iterations = 50
+
+	for _, pattern := range cases {
+		suite.Run(pattern, func() {
+			for i := 0; i < iterations; i++ {
+				code, err := generateVerificationCode(pattern)
+				suite.Require().NoError(err)
+				suite.Require().Len(code, len(pattern))
+				for pos, c := range []byte(code) {
+					var allowed string
+					switch pattern[pos] {
+					case 'F':
+						allowed = codeAlphabetFull
+					case 'D':
+						allowed = codeAlphabetDigit
+					}
+					suite.True(strings.ContainsRune(allowed, rune(c)),
+						"code %q pos %d: char %q not in alphabet %q", code, pos, c, allowed)
+				}
+			}
+		})
+	}
+}
+
+func (suite *VerificationsTestSuite) TestGenerateVerificationCodeInvalidPattern() {
+	cases := []string{"", "FFXFFD"}
+	for _, p := range cases {
+		suite.Run(p, func() {
+			code, err := generateVerificationCode(p)
+			suite.Require().Error(err, "expected error for pattern %q, got code=%q", p, code)
+		})
+	}
+}
+
+func (suite *VerificationsTestSuite) TestGenerateVerificationCodeDistribution() {
+	// Smoke test for non-determinism: a long enough run should not always
+	// return the same code. Catches obvious seeding/PRNG bugs.
+	const pattern = "FFDFFD"
+	const iterations = 50
+	seen := make(map[string]struct{}, iterations)
+	for i := 0; i < iterations; i++ {
+		code, err := generateVerificationCode(pattern)
+		suite.Require().NoError(err)
+		seen[code] = struct{}{}
+	}
+	suite.GreaterOrEqual(len(seen), iterations/2,
+		"expected mostly distinct codes over %d runs, got %d unique", iterations, len(seen))
+}
+
+func TestVerificationsTestSuite(t *testing.T) {
+	suite.Run(t, new(VerificationsTestSuite))
+}


### PR DESCRIPTION
This eliminates the possiblity of bad words in the output.

Generated codes are uniform over a 32/32/6/32/32/6 alphabet pattern, yielding approximately 25 bits of entropy.

Fixes #199