### PR TITLE
Replace verification deletion with invalidation

### DIFF
--- a/controllers/accounts.go
+++ b/controllers/accounts.go
@@ -399,8 +399,8 @@ func (ac *AccountsController) postPasswordSetup(ctx context.Context, accountID u
 		}
 	}
 
-	if err := ac.ds.DeleteVerification(verification.ID); err != nil {
-		return nil, false, fmt.Errorf("failed to delete verification: %w", err)
+	if err := ac.ds.InvalidateVerification(verification.ID); err != nil {
+		return nil, false, fmt.Errorf("failed to invalidate verification: %w", err)
 	}
 
 	return authToken, shouldInvalidateSessions, nil

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -247,8 +247,8 @@ func (ac *AuthController) Validate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := ac.ds.DeleteVerificationsByNewSessionID(session.ID); err != nil {
-		log.Error().Err(err).Msg("failed to delete verifications by session id")
+	if err := ac.ds.InvalidateVerificationsByNewSessionID(session.ID); err != nil {
+		log.Error().Err(err).Msg("failed to invalidate verifications by session id")
 	}
 
 	response := ValidateTokenResponse{

--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -200,7 +200,7 @@ func (vc *VerificationController) VerifyDelete(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err := vc.datastore.DeleteVerification(verification.ID); err != nil {
+	if err := vc.datastore.InvalidateVerification(verification.ID); err != nil {
 		util.RenderErrorResponse(w, r, http.StatusInternalServerError, err)
 		return
 	}

--- a/controllers/verification_test.go
+++ b/controllers/verification_test.go
@@ -605,7 +605,7 @@ func (suite *VerificationTestSuite) TestVerifyResend() {
 	suite.sesMock.AssertExpectations(suite.T())
 }
 
-func (suite *VerificationTestSuite) TestVerifyDelete() {
+func (suite *VerificationTestSuite) TestVerifyInvalidate() {
 	suite.SetupController(true, true)
 
 	email := "test@example.com"
@@ -625,13 +625,19 @@ func (suite *VerificationTestSuite) TestVerifyDelete() {
 	suite.Require().NoError(err)
 	suite.Nil(account.LastEmailVerifiedAt)
 
-	// Delete verification
+	// Invalidate verification
 	req := httptest.NewRequest(http.MethodDelete, "/v2/verify", nil)
 	req.Header.Set("Authorization", "Bearer "+*verificationToken)
 	resp := util.ExecuteTestRequest(req, suite.router)
 	suite.Equal(http.StatusNoContent, resp.Code)
 
-	// Verify verification was deleted
+	// Verify the record still exists in the DB with is_invalidated = true
+	var dbVerification datastore.Verification
+	err = suite.ds.DB.First(&dbVerification, "id = ?", verification.ID).Error
+	suite.Require().NoError(err)
+	suite.True(dbVerification.IsInvalidated)
+
+	// Verify GetVerificationStatus treats it as not found
 	_, err = suite.ds.GetVerificationStatus(verification.ID)
 	suite.ErrorIs(err, util.ErrVerificationNotFound)
 
@@ -640,7 +646,7 @@ func (suite *VerificationTestSuite) TestVerifyDelete() {
 	suite.ErrorIs(err, datastore.ErrAccountNotFound)
 }
 
-func (suite *VerificationTestSuite) TestVerifyDeleteForbidden() {
+func (suite *VerificationTestSuite) TestVerifyInvalidateForbidden() {
 	suite.SetupController(true, false)
 
 	// Use InitializeVerification to create an auth_token verification
@@ -654,7 +660,7 @@ func (suite *VerificationTestSuite) TestVerifyDeleteForbidden() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(*verificationToken)
 
-	// Delete verification - should be bad request for auth_token intent
+	// Invalidate verification - should be bad request for auth_token intent
 	req := httptest.NewRequest(http.MethodDelete, "/v2/verify", nil)
 	req.Header.Set("Authorization", "Bearer "+*verificationToken)
 	resp := util.ExecuteTestRequest(req, suite.router)
@@ -662,7 +668,7 @@ func (suite *VerificationTestSuite) TestVerifyDeleteForbidden() {
 	util.AssertErrorResponseCode(suite.T(), resp, util.ErrIntentNotAllowed.Code)
 }
 
-func (suite *VerificationTestSuite) TestVerifyDeleteAlreadyVerified() {
+func (suite *VerificationTestSuite) TestVerifyInvalidateAlreadyVerified() {
 	suite.SetupController(true, true)
 
 	// Use InitializeVerification to create a registration verification
@@ -680,7 +686,7 @@ func (suite *VerificationTestSuite) TestVerifyDeleteAlreadyVerified() {
 	err = suite.ds.DB.Model(&datastore.Verification{}).Where("id = ?", verification.ID).Update("verified", true).Error
 	suite.Require().NoError(err)
 
-	// Delete verification - should be bad request for already verified
+	// Invalidate verification - should be bad request for already verified
 	req := httptest.NewRequest(http.MethodDelete, "/v2/verify", nil)
 	req.Header.Set("Authorization", "Bearer "+*verificationToken)
 	resp := util.ExecuteTestRequest(req, suite.router)

--- a/datastore/verifications.go
+++ b/datastore/verifications.go
@@ -33,6 +33,8 @@ type Verification struct {
 	EmailAttempts int16
 	// CodeAttempts tracks the number of wrong-code submission attempts
 	CodeAttempts int16
+	// IsInvalidated indicates whether the verification has been invalidated
+	IsInvalidated bool
 	// CreatedAt records when the verification was initiated
 	CreatedAt time.Time `gorm:"<-:update"`
 }
@@ -49,6 +51,13 @@ const (
 	maxPendingVerifications = 3
 	MaxCodeAttempts         = 5
 )
+
+func (d *Datastore) validVerificationModel(v *Verification) *gorm.DB {
+	if v == nil {
+		v = &Verification{}
+	}
+	return d.DB.Model(v).Where("is_invalidated = false")
+}
 
 func generateVerificationCode() (string, error) {
 	b := make([]byte, codeLength)
@@ -82,7 +91,7 @@ func (d *Datastore) CreateVerification(email string, service string, intent stri
 	}
 
 	var existingCount int64
-	if err := d.DB.Model(&Verification{}).
+	if err := d.validVerificationModel(nil).
 		Where("email = ? AND verified = false AND created_at > ?",
 			email,
 			time.Now().Add(-VerificationExpiration)).
@@ -102,7 +111,7 @@ func (d *Datastore) CreateVerification(email string, service string, intent stri
 
 // MarkVerificationAsComplete marks the verification as verified
 func (d *Datastore) MarkVerificationAsComplete(id uuid.UUID) error {
-	result := d.DB.Model(&Verification{}).
+	result := d.validVerificationModel(nil).
 		Where("id = ?", id).
 		Update("verified", true)
 
@@ -117,10 +126,10 @@ func (d *Datastore) MarkVerificationAsComplete(id uuid.UUID) error {
 	return nil
 }
 
-// GetVerificationStatus fetches the verification record by ID, returning an error if expired or not found
+// GetVerificationStatus fetches the verification record by ID, returning an error if expired, invalidated, or not found
 func (d *Datastore) GetVerificationStatus(id uuid.UUID) (*Verification, error) {
 	var verification Verification
-	if err := d.DB.First(&verification, "id = ?", id).Error; err != nil {
+	if err := d.validVerificationModel(nil).First(&verification, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, util.ErrVerificationNotFound
 		}
@@ -128,19 +137,18 @@ func (d *Datastore) GetVerificationStatus(id uuid.UUID) (*Verification, error) {
 	}
 
 	if time.Since(verification.CreatedAt) > VerificationExpiration {
-		if err := d.DB.Delete(&verification).Error; err != nil {
-			return nil, fmt.Errorf("error deleting expired verification: %w", err)
-		}
 		return nil, util.ErrVerificationNotFound
 	}
 
 	return &verification, nil
 }
 
-func (d *Datastore) DeleteVerification(id uuid.UUID) error {
-	result := d.DB.Delete(&Verification{}, "id = ?", id)
+func (d *Datastore) InvalidateVerification(id uuid.UUID) error {
+	result := d.validVerificationModel(nil).
+		Where("id = ?", id).
+		Update("is_invalidated", true)
 	if result.Error != nil {
-		return fmt.Errorf("failed to delete verification: %w", result.Error)
+		return fmt.Errorf("failed to invalidate verification: %w", result.Error)
 	}
 
 	if result.RowsAffected == 0 {
@@ -151,7 +159,7 @@ func (d *Datastore) DeleteVerification(id uuid.UUID) error {
 }
 
 func (d *Datastore) SetVerificationNewSessionID(id uuid.UUID, sessionID uuid.UUID) error {
-	result := d.DB.Model(&Verification{}).
+	result := d.validVerificationModel(nil).
 		Where("id = ?", id).
 		Update("new_session_id", sessionID)
 
@@ -166,17 +174,19 @@ func (d *Datastore) SetVerificationNewSessionID(id uuid.UUID, sessionID uuid.UUI
 	return nil
 }
 
-func (d *Datastore) DeleteVerificationsByNewSessionID(sessionID uuid.UUID) error {
-	result := d.DB.Delete(&Verification{}, "new_session_id = ?", sessionID)
+func (d *Datastore) InvalidateVerificationsByNewSessionID(sessionID uuid.UUID) error {
+	result := d.validVerificationModel(nil).
+		Where("new_session_id = ?", sessionID).
+		Update("is_invalidated", true)
 	if result.Error != nil {
-		return fmt.Errorf("failed to delete verifications by session id: %w", result.Error)
+		return fmt.Errorf("failed to invalidate verifications by session id: %w", result.Error)
 	}
 
 	return nil
 }
 
 func (d *Datastore) IncrementVerificationEmailAttempts(id uuid.UUID) error {
-	result := d.DB.Model(&Verification{}).
+	result := d.validVerificationModel(nil).
 		Where("id = ?", id).
 		Update("email_attempts", gorm.Expr("email_attempts + 1"))
 
@@ -192,7 +202,7 @@ func (d *Datastore) IncrementVerificationEmailAttempts(id uuid.UUID) error {
 }
 
 func (d *Datastore) DecrementVerificationEmailAttempts(id uuid.UUID) error {
-	result := d.DB.Model(&Verification{}).
+	result := d.validVerificationModel(nil).
 		Where("id = ?", id).
 		Update("email_attempts", gorm.Expr("email_attempts - 1"))
 
@@ -209,7 +219,7 @@ func (d *Datastore) DecrementVerificationEmailAttempts(id uuid.UUID) error {
 
 func (d *Datastore) IncrementVerificationCodeAttempts(id uuid.UUID) (int16, error) {
 	var verification Verification
-	result := d.DB.Model(&verification).
+	result := d.validVerificationModel(&verification).
 		Clauses(clause.Returning{Columns: []clause.Column{{Name: "code_attempts"}}}).
 		Where("id = ?", id).
 		Update("code_attempts", gorm.Expr("code_attempts + 1"))

--- a/migrations/20260609004200_verify_invalidate.down.sql
+++ b/migrations/20260609004200_verify_invalidate.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE verifications DROP COLUMN is_invalidated;

--- a/migrations/20260609004200_verify_invalidate.up.sql
+++ b/migrations/20260609004200_verify_invalidate.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE verifications ADD COLUMN is_invalidated BOOL NOT NULL DEFAULT FALSE;

--- a/services/verification.go
+++ b/services/verification.go
@@ -107,7 +107,7 @@ func (vs *VerificationService) SendVerificationEmail(ctx context.Context, verifi
 	// Send verification email
 	if err := vs.sesService.SendVerificationEmail(ctx, verification.Email, verification, locale); err != nil {
 		if errors.Is(err, util.ErrFailedToSendEmailInvalidFormat) {
-			if vs.datastore.DeleteVerification(verification.ID) != nil {
+			if vs.datastore.InvalidateVerification(verification.ID) != nil {
 				// Don't override the more descriptive error code and let cron handle the cleanup
 				_ = true
 			}


### PR DESCRIPTION
Adds a `is_invalidated` bool to the verification table. Replace all hard deletes with soft deletes, so we can effectively enforce dairy verification limits.