### PR TITLE
Enable translations present in templates/strings/

### DIFF
--- a/misc/test-client-rust/src/main.rs
+++ b/misc/test-client-rust/src/main.rs
@@ -53,6 +53,10 @@ struct CliArgs {
     #[arg(long)]
     service_name: Option<String>,
 
+    /// Locale for verification emails (e.g. "en-US", "es-ES")
+    #[arg(long)]
+    locale: Option<String>,
+
     /// Set brave-services-key header
     #[arg(short = 'k', long)]
     services_key: Option<String>,
@@ -243,6 +247,10 @@ fn verify(args: &CliArgs) -> (String, Option<String>) {
         Value::String(args.email.as_ref().expect("email must be provided").clone()),
     );
 
+    if let Some(locale) = args.locale.as_ref() {
+        body.insert("locale", locale.clone().into());
+    }
+
     let auth_token = if args.change_password {
         Some(
             args.token
@@ -355,6 +363,10 @@ fn set_password(args: CliArgs) {
 
     let mut body: HashMap<&str, Value> = HashMap::new();
     body.insert("serializedRecord", record_hex.into());
+
+    if let Some(locale) = args.locale.as_ref() {
+        body.insert("locale", locale.clone().into());
+    }
 
     if args.change_password && args.invalidate_sessions {
         body.insert("invalidateSessions", true.into());

--- a/templates/embedded.go
+++ b/templates/embedded.go
@@ -1,6 +1,6 @@
 package templates
 
-import _ "embed"
+import "embed"
 
 //go:embed verify_html.tmpl
 var VerifyHTMLTemplateContent string
@@ -17,5 +17,5 @@ var GeneralEmailTextTemplateContent string
 //go:embed email_viewer.tmpl
 var EmailViewerTemplateContent string
 
-//go:embed strings/en.toml
-var StringsEnToml []byte
+//go:embed strings/*.toml
+var StringsFS embed.FS

--- a/util/i18n.go
+++ b/util/i18n.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"fmt"
+	"io/fs"
+	"slices"
 
 	"github.com/BurntSushi/toml"
 	"github.com/brave/accounts/templates"
@@ -12,8 +14,18 @@ import (
 func CreateI18nBundle() (*i18n.Bundle, error) {
 	i18nBundle := i18n.NewBundle(language.English)
 	i18nBundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
-	if _, err := i18nBundle.ParseMessageFileBytes(templates.StringsEnToml, "en.toml"); err != nil {
-		return nil, fmt.Errorf("failed to load en strings: %w", err)
+
+	files, err := fs.Glob(templates.StringsFS, "strings/*.toml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list locale strings: %w", err)
+	}
+	if !slices.Contains(files, "strings/en.toml") {
+		return nil, fmt.Errorf("required en.toml strings not found")
+	}
+	for _, file := range files {
+		if _, err := i18nBundle.LoadMessageFileFS(templates.StringsFS, file); err != nil {
+			return nil, fmt.Errorf("failed to load %s strings: %w", file, err)
+		}
 	}
 	return i18nBundle, nil
 }


### PR DESCRIPTION
Right now, that's just English and French.

English is the default / fallback and its presence is mandatory.

Needed for #161.