### PR TITLE
Add graceful shutdown support

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -53,6 +54,17 @@ func addSwaggerToRouter(r *chi.Mux) {
 	}
 }
 
+func listenAndServe(handler http.Handler) {
+	srv := &http.Server{Addr: *listenFlag, Handler: handler}
+	shutdownDone := util.SetupGracefulShutdownListener(srv)
+
+	log.Info().Msgf("Server listening on %v", *listenFlag)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Panic().Err(err).Msg("Failed to start server")
+	}
+	<-shutdownDone
+}
+
 func startKeyService(jwtService *services.JWTService, opaqueService *services.OpaqueService, twoFAService *services.TwoFAService, environment string) {
 	// Initialize controllers
 	serverKeysController := controllers.NewServerKeysController(opaqueService, jwtService, twoFAService)
@@ -67,10 +79,7 @@ func startKeyService(jwtService *services.JWTService, opaqueService *services.Op
 
 	util.StartPrometheusServer(prometheusRegistry, *prometheusListenFlag)
 
-	log.Info().Msgf("Server listening on %v", *listenFlag)
-	if err := http.ListenAndServe(*listenFlag, r); err != nil {
-		log.Panic().Err(err).Msg("Failed to start server")
-	}
+	listenAndServe(r)
 }
 
 // @title Brave Accounts Service
@@ -206,8 +215,5 @@ func main() {
 
 	util.StartPrometheusServer(prometheusRegistry, *prometheusListenFlag)
 
-	log.Info().Msgf("Server listening on %v", *listenFlag)
-	if err := http.ListenAndServe(*listenFlag, r); err != nil {
-		log.Panic().Err(err).Msg("Failed to start server")
-	}
+	listenAndServe(r)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -11,8 +11,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/signal"
 	"regexp"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -48,6 +51,8 @@ const (
 	recoveryKeyArgonKeyLength  = 32
 	recoveryKeyArgonSaltLength = 16
 	recoveryKeyFullHashLength  = recoveryKeyArgonKeyLength + recoveryKeyArgonSaltLength
+
+	gracefulShutdownTimeout 	 = 30 * time.Second
 )
 
 func generateRecoveryKeyHash(recoveryKey string, salt []byte) []byte {
@@ -180,6 +185,32 @@ func ListenOnPGChannel(ctx context.Context, conn *pgxpool.Conn, channelName stri
 	}
 	_, err := conn.Exec(ctx, "LISTEN \""+channelName+"\"")
 	return err
+}
+
+// SetupGracefulShutdownListener gracefully shuts down srv on SIGINT/SIGTERM.
+// The returned channel is closed once shutdown completes; wait on it after
+// ListenAndServe to ensure in-flight requests are drained.
+func SetupGracefulShutdownListener(srv *http.Server) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+		sig := <-sigChan
+		log.Info().Msgf("Received signal %v, shutting down gracefully", sig)
+
+		ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		defer cancel()
+
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Error().Err(err).Msg("Failed to gracefully shut down server")
+			return
+		}
+		log.Info().Msg("Server shut down gracefully")
+	}()
+	return done
 }
 
 func StartPrometheusServer(registry *prometheus.Registry, listen string) {


### PR DESCRIPTION
When the container orchestrator or developer invokes SIGTERM, stop listening for new connections and wait for existing connections to finish up before terminating.