### PR TITLE
prompting for email length is exceeding the limit

### DIFF
--- a/controllers/accounts.go
+++ b/controllers/accounts.go
@@ -274,6 +274,11 @@ func (ac *AccountsController) SetupPasswordInit(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	if len(*requestData.NewAccountEmail) > 254 {
+		util.RenderErrorResponse(w, r, http.StatusBadRequest, util.ErrEmailTooLong)
+		return
+	}
+
 	var verificationToken *string
 	var verificationTokenExpiresAt *time.Time
 	if verification != nil {

--- a/controllers/accounts_test.go
+++ b/controllers/accounts_test.go
@@ -793,3 +793,22 @@ func TestAccountsTestSuite(t *testing.T) {
 		suite.Run(t, NewAccountsTestSuite(true))
 	})
 }
+
+func (suite *AccountsTestSuite) TestRegistrationEmailTooLong() {
+	// Create an email that exceeds 254 characters
+	longEmail := strings.Repeat("a", 255) + "@example.com"
+	registrationReq := suite.opaqueClient.RegistrationInit([]byte("testtest1"))
+
+	// Test password init with email exceeding length limit
+	req := util.CreateJSONTestRequest("/v2/accounts/password/init", controllers.RegistrationRequest{
+		BlindedMessage        : hex.EncodeToString(registrationReq.Serialize()),
+		SerializeResponse     : true,
+		NewAccountEmail       : &longEmail,
+		InitiatingServiceName : util.AccountsServiceName,
+	})
+	// No Authorization header for registration
+
+	resp := util.ExecuteTestRequest(req, suite.router)
+	suite.Equal(http.StatusBadRequest, resp.Code)
+	util.AssertErrorResponseCode(suite.T(), resp, util.ErrEmailTooLong.Code)
+}

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -282,6 +282,11 @@ func (ac *AuthController) LoginInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(requestData.Email) > 254 {
+		util.RenderErrorResponse(w, r, http.StatusBadRequest, util.ErrEmailTooLong)
+		return
+	}
+
 	if !util.IsEmailAllowed(requestData.Email) {
 		util.RenderErrorResponse(w, r, http.StatusBadRequest, util.ErrEmailDomainNotSupported)
 		return

--- a/controllers/auth_test.go
+++ b/controllers/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -606,4 +607,24 @@ func TestAuthTestSuite(t *testing.T) {
 	t.Run("WithKeyService", func(t *testing.T) {
 		suite.Run(t, NewAuthTestSuite(true))
 	})
+}
+
+func (suite *AuthTestSuite) TestAuthLoginEmailTooLong() {
+	opaqueClient, err := opaque.NewClient(suite.opaqueConfig)
+	suite.Require().NoError(err)
+
+	// Create an email that exceeds 254 characters
+	longEmail := strings.Repeat("a", 255) + "@example.com"
+	ke1 := opaqueClient.GenerateKE1([]byte("testtest1"))
+	serializedKE1 := hex.EncodeToString(ke1.Serialize())
+	loginReq := controllers.LoginInitRequest{
+		Email:                 longEmail,
+		SerializedKE1:         &serializedKE1,
+		InitiatingServiceName: util.AccountsServiceName,
+	}
+
+	req := util.CreateJSONTestRequest("/v2/auth/login/init", loginReq)
+	resp := util.ExecuteTestRequest(req, suite.router)
+	suite.Equal(http.StatusBadRequest, resp.Code)
+	util.AssertErrorResponseCode(suite.T(), resp, util.ErrEmailTooLong.Code)
 }

--- a/controllers/verification.go
+++ b/controllers/verification.go
@@ -143,6 +143,11 @@ func (vc *VerificationController) VerifyInit(w http.ResponseWriter, r *http.Requ
 		session,
 	)
 
+	if len(requestData.Email) > 254 {
+		util.RenderErrorResponse(w, r, http.StatusBadRequest, util.ErrEmailTooLong)
+		return
+	}
+
 	if err != nil {
 		if errors.Is(err, util.ErrTooManyVerifications) ||
 			errors.Is(err, util.ErrDailyVerificationLimitReached) ||

--- a/controllers/verification_test.go
+++ b/controllers/verification_test.go
@@ -717,3 +717,19 @@ func TestVerificationTestSuite(t *testing.T) {
 		suite.Run(t, NewVerificationTestSuite(true))
 	})
 }
+
+func (suite *VerificationTestSuite) TestVerifyInitEmailTooLong() {
+	suite.sesMock.On("SendVerificationEmail", mock.Anything, mock.Anything, mock.Anything, "en-US").Return(nil).Maybe()
+
+	// Test email exceeding 254 characters
+	longEmail := strings.Repeat("a", 250) + "@example.com"
+	body := controllers.VerifyInitRequest{
+		Email:   longEmail,
+		Intent:  "auth_token",
+		Service: "email-aliases",
+		Locale:  "en-US",
+	}
+	resp := util.ExecuteTestRequest(util.CreateJSONTestRequest("/v2/verify/init", body), suite.router)
+	suite.Equal(http.StatusBadRequest, resp.Code)
+	util.AssertErrorResponseCode(suite.T(), resp, util.ErrEmailTooLong.Code)
+}

--- a/util/error.go
+++ b/util/error.go
@@ -36,6 +36,7 @@ var (
 	ErrInvalidCode                     = NewExposedError(13011, "invalid verification code")
 	ErrRegistrationVerificationPending = NewExposedError(13012, "registration verification already pending for this email")
 	ErrDailyVerificationLimitReached   = NewExposedError(13013, "daily verification limit reached for email")
+	ErrEmailTooLong                    = NewExposedError(13014, "email address exceeds maximum length of 254 characters")
 
 	// Auth errors, prefixed with '14'
 	ErrInterimPasswordStateNotFound = NewExposedError(14001, "interim password state not found")

--- a/util/util.go
+++ b/util/util.go
@@ -168,8 +168,8 @@ func DecodeJSONAndValidate(w http.ResponseWriter, r *http.Request, data interfac
 
 	// Translate specific validator failures into shared exposed API errors.
 	//
-	// Validator errors are generic, and the response formatter only emits
-	// error codes for exposed errors. For email max-length failures we want
+	// Validator errors are generic (e.x. "validation failed"), and the response formatter
+	// only emits error codes for exposed errors. For email max-length failures we want
 	// to return ErrEmailTooLong instead of a general validation error.
 	if err := validate.Struct(data); err != nil {
 		if validationErr, ok := errors.AsType[validator.ValidationErrors](err); ok {

--- a/util/util.go
+++ b/util/util.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -52,7 +53,7 @@ const (
 	recoveryKeyArgonSaltLength = 16
 	recoveryKeyFullHashLength  = recoveryKeyArgonKeyLength + recoveryKeyArgonSaltLength
 
-	gracefulShutdownTimeout 	 = 30 * time.Second
+	gracefulShutdownTimeout = 30 * time.Second
 )
 
 func generateRecoveryKeyHash(recoveryKey string, salt []byte) []byte {
@@ -165,7 +166,20 @@ func DecodeJSONAndValidate(w http.ResponseWriter, r *http.Request, data interfac
 		return false
 	}
 
+	// Translate specific validator failures into shared exposed API errors.
+	//
+	// Validator errors are generic, and the response formatter only emits
+	// error codes for exposed errors. For email max-length failures we want
+	// to return ErrEmailTooLong instead of a general validation error.
 	if err := validate.Struct(data); err != nil {
+		if validationErr, ok := errors.AsType[validator.ValidationErrors](err); ok {
+			for _, ve := range validationErr {
+				if ve.Tag() == "max" && strings.HasSuffix(ve.Field(), "Email") {
+					RenderErrorResponse(w, r, http.StatusBadRequest, ErrEmailTooLong)
+					return false
+				}
+			}
+		}
 		RenderErrorResponse(w, r, http.StatusBadRequest, err)
 		return false
 	}


### PR DESCRIPTION
The implementation adds manual length checks (#148) in the three main email-handling endpoints (`LoginInit`, `VerifyInit`, and `SetupPasswordInit`) that return **ErrEmailTooLong** (error code **13010**) when exceeded, rather than relying on struct tag validation to ensure consistent error code handling across the API.
