### PR TITLE
Remove alt text for Brave logo in emails

### DIFF
--- a/templates/email_general_html.tmpl
+++ b/templates/email_general_html.tmpl
@@ -98,9 +98,9 @@
                   <tr>
                     <td align="center" style="padding-top: 48px">
                       <a href="https://brave.com" style="color: #3e37d4">
-                        <span class="dark-hidden light-hidden" style="display: block"><img width="144" height="48" src="https://account.brave.com/images/email/brave-288x96.png" alt="Brave.com logo" style="max-width: 100%; vertical-align: middle"></span>
-                        <span class="dark-hidden light-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-dark-288x96.png" alt="Brave.com logo" style="max-width: 100%; vertical-align: middle"></span>
-                        <span class="dark-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-white-288x96.png" alt="Brave.com logo" style="max-width: 100%; vertical-align: middle"></span>
+                        <span class="dark-hidden light-hidden" style="display: block"><img width="144" height="48" src="https://account.brave.com/images/email/brave-288x96.png" style="max-width: 100%; vertical-align: middle"></span>
+                        <span class="dark-hidden light-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-dark-288x96.png" style="max-width: 100%; vertical-align: middle"></span>
+                        <span class="dark-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-white-288x96.png" style="max-width: 100%; vertical-align: middle"></span>
                       </a>
                     </td>
                   </tr>

--- a/templates/verify_html.tmpl
+++ b/templates/verify_html.tmpl
@@ -108,9 +108,9 @@
                   <tr>
                     <td align="center" style="padding-top: 48px">
                       <a href="https://brave.com" style="color: #3e37d4">
-                        <span class="dark-hidden light-hidden" style="display: block"><img width="144" height="48" src="https://account.brave.com/images/email/brave-288x96.png" alt="Brave.com logo" style="max-width: 100%; vertical-align: middle"></span>
-                        <span class="dark-hidden light-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-dark-288x96.png" alt="Brave.com logo" style="max-width: 100%; vertical-align: middle"></span>
-                        <span class="dark-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-white-288x96.png" alt="Brave.com logo" style="max-width: 100%; vertical-align: middle"></span>
+                        <span class="dark-hidden light-hidden" style="display: block"><img width="144" height="48" src="https://account.brave.com/images/email/brave-288x96.png" style="max-width: 100%; vertical-align: middle"></span>
+                        <span class="dark-hidden light-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-dark-288x96.png" style="max-width: 100%; vertical-align: middle"></span>
+                        <span class="dark-block" style="display: none"><img width="144" height="48" src="https://account.brave.com/images/email/brave-white-288x96.png" style="max-width: 100%; vertical-align: middle"></span>
                       </a>
                     </td>
                   </tr>


### PR DESCRIPTION
The alt text appears in Gmail email previews, which is undesirable. 